### PR TITLE
Split out the storjshare binary from the path

### DIFF
--- a/storjreports/register_server.py
+++ b/storjreports/register_server.py
@@ -80,7 +80,7 @@ def find_storjshare():
     results = proc.communicate()
     possible_path = results[0].decode('utf-8').replace('\n', '')
     if '/' in possible_path:
-        STORJSHAREPATH = possible_path
+        STORJSHAREPATH = possible_path.split('storjshare')[0][:-1]
         return
     user_directories = scandir('/home')
 


### PR DESCRIPTION
This resolves an issue where the binary name was included in the path of the config file, which caused cron to fail.